### PR TITLE
fix void pointer causing undefined behavior in arithmetic operations

### DIFF
--- a/kfifo.c
+++ b/kfifo.c
@@ -124,8 +124,8 @@ static void kfifo_copy_in(struct __kfifo *fifo, const void *src,
 	}
 	l = min(len, size - off);
 
-	memcpy(fifo->data + off, src, l);
-	memcpy(fifo->data, src + l, len - l);
+	memcpy((char *)fifo->data + off, src, l);
+	memcpy(fifo->data, (char *)src + l, len - l);
 	/*
 	 * make sure that the data in the fifo is up to date before
 	 * incrementing the fifo->in index counter
@@ -163,8 +163,8 @@ static void kfifo_copy_out(struct __kfifo *fifo, void *dst,
 	}
 	l = min(len, size - off);
 
-	memcpy(dst, fifo->data + off, l);
-	memcpy(dst + l, fifo->data, len - l);
+	memcpy(dst, (char *)fifo->data + off, l);
+	memcpy((char *)dst + l, fifo->data, len - l);
 	/*
 	 * make sure that the data is copied before
 	 * incrementing the fifo->out index counter

--- a/list.h
+++ b/list.h
@@ -38,8 +38,8 @@
 #define READ_ONCE(x) (x)
 
 // liigo 20200212: copy from linux/poison.h
-#define LIST_POISON1  ((void *) 0x100 + 0)
-#define LIST_POISON2  ((void *) 0x122 + 0)
+#define LIST_POISON1  ((char *) 0x100 + 0)
+#define LIST_POISON2  ((char *) 0x122 + 0)
 
 // liigo 20200212: copy from linux/types.h
 struct list_head {


### PR DESCRIPTION
In the current implementation, some void pointer arithmetic is performed, which results in undefined behavior according to spec. Although many compilers like gcc treat void pointers as char pointers, it's better to eliminate this uncertainty to improve compatibility and portability, and my static code analyzer, CppCheck, also won't go crazy over it anymore.
This pull request fixes these issues by replacing void pointers with char pointers.